### PR TITLE
less prints for better performance in output mode

### DIFF
--- a/factorize.py
+++ b/factorize.py
@@ -75,8 +75,8 @@ def factorize(n, __output=False):
 
 	operator = '=' # the operator to display. either '=' or '*'
 	limit = ceil(sqrt(n))
-	for prime in primes():
-		if __output:
+	for idx, prime in enumerate(primes()):
+		if __output and idx % 100 == 0:
 			print('%c %d (calculated primes up to %d ...)' %
 					(operator, n, prime), end='\r')
 


### PR DESCRIPTION
Printing is a costly operation. This introduces a mechanism so that we don't output as often. This leads to some performance improvement.

```bash
$ time python factorize.py 2595925957847039                        
2595925957847039
= 38047
* 140281
* 486377
python factorize.py 2595925957847039  5.73s user 0.01s system 99% cpu 5.742 total
$ git checkout master
Switched to branch 'master'
$ time python factorize.py 2595925957847039
2595925957847039
= 38047
* 140281
* 486377
python factorize.py 2595925957847039  6.19s user 0.04s system 99% cpu 6.257 total```
